### PR TITLE
feat: supabase 데이터 패치 및 Detail/FeedEdit 페이지 구현 #16

### DIFF
--- a/src/api/fetchData.js
+++ b/src/api/fetchData.js
@@ -2,7 +2,7 @@ import supabase from "../supabase/client";
 
 export const fetchData = async (table) => {
   try {
-    const { data } = await supabase.from(table).select("*");
+    const { data } = await supabase.from(table).select("contents, created_at, feed_id, title, users(*)");
 
     return data;
   } catch (error) {

--- a/src/api/fetchData.js
+++ b/src/api/fetchData.js
@@ -1,18 +1,19 @@
 import supabase from "../supabase/client";
 
-/** 해당 table의 데이터를 가져오는 로직
+/** 해당 table의 데이터를 join해서 가져오는 로직
  *
  * @param {"string"} table
  * @returns Promise객체
  *
  * 사용할 컴포넌트에서 async 함수로 감싼 후 사용해야합니다!
+ * 단, users 테이블과 fk로 연결되어있어야 합니다.
  */
-export const fetchData = async (table) => {
+export const fetchData = async (table1, table2) => {
   try {
-    const { data } = await supabase.from(table).select("contents, created_at, feed_id, title, users(*)");
+    const { data } = await supabase.from(table1).select(`*, ${table2}(*)`);
 
     return data;
   } catch (error) {
-    console.log("error", error);
+    console.log("fetching error", error);
   }
 };

--- a/src/components/feed/Comments.jsx
+++ b/src/components/feed/Comments.jsx
@@ -1,0 +1,5 @@
+const Comments = () => {
+  return <div>Comments</div>;
+};
+
+export default Comments;

--- a/src/components/feed/Comments.jsx
+++ b/src/components/feed/Comments.jsx
@@ -1,5 +1,118 @@
-const Comments = () => {
-  return <div>Comments</div>;
+import styled from "styled-components";
+import Button from "../../common/Button";
+import { useState } from "react";
+import { useEffect } from "react";
+import { fetchData } from "../../api/fetchData.js";
+
+const Comments = ({ feedId }) => {
+  //-----data fetch-----
+  const [commentsData, setCommentsData] = useState([]);
+
+  useEffect(() => {
+    async function fetchComments() {
+      try {
+        const comments = await fetchData("comments", "users");
+        //해당 게시글의 댓글만 가져오기
+        const newComments = comments.filter(
+          (comment) => comment.feed_id === feedId
+        );
+
+        setCommentsData(newComments);
+      } catch (error) {
+        console.log("fetching error => ", error);
+      }
+    }
+
+    fetchComments();
+  }, []);
+
+  return (
+    <>
+      <StDetailCommentsWrapper>
+        <h1>Comments</h1>
+        {/* map돌려서 넣기 */}
+        {!commentsData ? (
+          <p>아직 댓글이 없습니다</p>
+        ) : (
+          commentsData.map((comment) => {
+            return (
+              <StDetailComment key={comment.comment_id}>
+                <img src={comment.users.profile_img} alt="user_profile_img" />
+                <h3>{comment.users.nickname}</h3>
+                <p>{comment.comment}</p>
+              </StDetailComment>
+            );
+          })
+        )}
+      </StDetailCommentsWrapper>
+
+      <StCommentForm>
+        <StCommentInput type="text" placeholder="댓글을 작성해주세요" />
+        <Button type="submit">SUBMIT</Button>
+      </StCommentForm>
+    </>
+  );
 };
+
+//-----styled-components-----
+//댓글 영역
+const StDetailCommentsWrapper = styled.ul`
+  width: 100%;
+  margin-top: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  border-top: 1px solid #504ba1;
+
+  h1 {
+    font-size: 20px;
+    padding: 0 5px;
+    margin: 20px 0;
+  }
+`;
+
+const StDetailComment = styled.li`
+  width: 100%;
+  display: flex;
+  align-items: center;
+
+  img {
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+    background: #ffa600;
+    margin-right: 10px;
+  }
+
+  h3 {
+    width: 10%;
+    font-size: 17px;
+    margin-right: 20px;
+  }
+
+  p {
+    width: 70%;
+    font-size: 12px;
+  }
+`;
+
+//댓글 입력 영역
+const StCommentForm = styled.form`
+  width: 100%;
+  margin-top: 50px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 20px;
+`;
+
+const StCommentInput = styled.input`
+  width: 500px;
+  height: 30px;
+  border-radius: 30px;
+  border: 1px solid #504ba1;
+  font-size: 12px;
+  padding: 0 20px;
+`;
 
 export default Comments;

--- a/src/components/feed/FeedCard.jsx
+++ b/src/components/feed/FeedCard.jsx
@@ -5,16 +5,16 @@ const FeedCard = ({ post }) => {
   return (
     <StFeedCard>
       <StFeedCardHeader>
-        <StProfileImage src={post.img_url} />
-
-        <StCardTitle>
-          {post.title}
+        <StProfileImage src={""} />
+        <StCardId>
+          {post.writer_id}
           <Like />
-        </StCardTitle>
+        </StCardId>
       </StFeedCardHeader>
 
       <StFeedCardContent>
-        {post.content}
+        {post.title}
+        {post.contents}
       </StFeedCardContent>
     </StFeedCard>
   )
@@ -48,7 +48,7 @@ const StProfileImage = styled.img`
   flex-shrink: 0;
 `;
 
-const StCardTitle = styled.h2`
+const StCardId = styled.h2`
   font-size: 18px;
   font-weight: bold;
   display: flex;

--- a/src/components/feed/FeedCard.jsx
+++ b/src/components/feed/FeedCard.jsx
@@ -5,9 +5,9 @@ const FeedCard = ({ post }) => {
   return (
     <StFeedCard>
       <StFeedCardHeader>
-        <StProfileImage src={""} />
+        <StProfileImage src={post.users.profile_img} />
         <StCardId>
-          {post.writer_id}
+          {post.users.nickname}
           <Like />
         </StCardId>
       </StFeedCardHeader>
@@ -20,6 +20,9 @@ const FeedCard = ({ post }) => {
   )
 }
 
+//-----styled-components-----
+
+// Feed카드
 const StFeedCard = styled.li`
   width: 400px;
   max-width: 600px;
@@ -36,10 +39,13 @@ const StFeedCard = styled.li`
     transform: translateY(-3px);
   }
 `
+
+// 카드 header
 const StFeedCardHeader = styled.div`
   display: flex;
 `
 
+// 프로필 이미지
 const StProfileImage = styled.img`
   width: 40px;
   height: 40px;
@@ -48,6 +54,7 @@ const StProfileImage = styled.img`
   flex-shrink: 0;
 `;
 
+// 게시글 작성자 ID
 const StCardId = styled.h2`
   font-size: 18px;
   font-weight: bold;
@@ -55,6 +62,7 @@ const StCardId = styled.h2`
   align-items: center;
 `;
 
+// 게시글 내용
 const StFeedCardContent = styled.p`
   font-size: 16px;
   color: #333;

--- a/src/components/feed/FeedForm.jsx
+++ b/src/components/feed/FeedForm.jsx
@@ -3,7 +3,7 @@ import Button from "../../common/Button";
 
 const FeedForm = () => {
   return (
-    <form>
+    <StForm>
       {/* 타이틀 인풋 영역 */}
       <StFormTitleWrapper>
         <h1>Title</h1>
@@ -16,14 +16,23 @@ const FeedForm = () => {
       </StFormContentsWrapper>
       {/* SUBMIT 버튼 영역 */}
       <Button>SUBMIT</Button>
-    </form>
+    </StForm>
   );
 };
 
 //-----styled-components-----
+//전체 레이아웃
+const StForm = styled.form`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
 //타이틀 인풋 영역
 const StFormTitleWrapper = styled.div`
-  width: 80%;
+  width: 100%;
   display: flex;
   flex-direction: column;
   gap: 5px;
@@ -37,7 +46,8 @@ const StFormTitleWrapper = styled.div`
 const StFormTitleInput = styled.input`
   width: 90%;
   height: 30px;
-  border: 1px solid #504ba1;
+  background: #4f4ba164;
+  border: none;
   border-radius: 20px;
   padding: 0 20px;
   font-size: 15px;
@@ -47,7 +57,7 @@ const StFormTitleInput = styled.input`
 
 //본문 인풋 영역
 const StFormContentsWrapper = styled.div`
-  width: 80%;
+  width: 100%;
   display: flex;
   flex-direction: column;
   gap: 5px;
@@ -61,7 +71,8 @@ const StFormContentsWrapper = styled.div`
 const StFormContentsInput = styled.textarea`
   width: 90%;
   height: 300px;
-  border: 1px solid #504ba1;
+  background: #4f4ba164;
+  border: none;
   border-radius: 20px;
   padding: 20px;
   font-size: 12px;

--- a/src/components/feed/FeedForm.jsx
+++ b/src/components/feed/FeedForm.jsx
@@ -68,7 +68,6 @@ const StFormContentsInput = styled.textarea`
   line-height: 30px;
   margin-left: 5px;
   overflow-wrap: break-word;
-  overflow-y: scroll;
 `;
 
 export default FeedForm;

--- a/src/components/feed/FeedList.jsx
+++ b/src/components/feed/FeedList.jsx
@@ -7,7 +7,7 @@ const FeedList = ({ posts }) => {
     <StFeedList>
       {posts.map((post) => {
         return (
-          <Link to={`/detail`} key={post.id}>
+          <Link to={`/detail?id=${post.feed_id}`} key={post.id}>
             <FeedCard post={post} />
           </Link>
         );

--- a/src/components/feed/FeedList.jsx
+++ b/src/components/feed/FeedList.jsx
@@ -1,20 +1,22 @@
-import { Link } from "react-router-dom"
+import { Link } from "react-router-dom";
 import FeedCard from "./FeedCard";
 import styled from "styled-components";
 
 const FeedList = ({ posts }) => {
   return (
-    <StFeedList>
-      {posts.map((post) => {
-        return (
-          <Link to={`/detail`} key={post.id}>
-            <FeedCard post={post} />
-          </Link>
-        );
-      })}
-    </StFeedList>
-  )
-}
+    <>
+      <StFeedList>
+        {posts.map((post) => {
+          return (
+            <Link to={`/detail`} key={post.id}>
+              <FeedCard post={post} />
+            </Link>
+          );
+        })}
+      </StFeedList>
+    </>
+  );
+};
 
 const StFeedList = styled.ul`
   list-style: none;
@@ -22,6 +24,6 @@ const StFeedList = styled.ul`
   flex-direction: column;
   align-items: center;
   gap: 15px;
-`
+`;
 
-export default FeedList
+export default FeedList;

--- a/src/pages/Detail.jsx
+++ b/src/pages/Detail.jsx
@@ -5,6 +5,7 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { useEffect } from "react";
 import { fetchData } from "../api/fetchData";
 import { useState } from "react";
+import Comments from "../components/feed/Comments";
 
 const Detail = () => {
   //-----url에서 게시글 id 추출-----
@@ -15,7 +16,6 @@ const Detail = () => {
   //-----data fetch-----
   //feeds, comments 테이블 Data 가져오기
   const [feedsData, setFeedsData] = useState([]);
-  const [commentsData, setCommentsData] = useState([]);
 
   useEffect(() => {
     async function fetchFeeds() {
@@ -50,32 +50,7 @@ const Detail = () => {
         <Button type="type">EDIT</Button>
       </StDetailUserContentsWrapper>
 
-      <StDetailCommentsWrapper>
-        <h1>Comments</h1>
-        {/* map돌려서 넣기 */}
-        {/* 예시 */}
-        <StDetailComment>
-          <img src="/" alt="user_profile_img" />
-          <h3>user</h3>
-          <p>
-            Lorem ipsum dolor sit amet consectetur adipisicing elit. Harum
-            labore nostrum corporis commodi laudantium vero quasi omnis enim
-            saepe, nobis voluptate beatae quidem ipsa nulla atque sequi,
-            aspernatur facere delectus.
-          </p>
-          <Button type="button">EDIT</Button>
-        </StDetailComment>
-        <StDetailComment>
-          <img src="/" alt="user_profile_img" />
-          <h3>sample456</h3>
-          <p>Loremslkdjflsdlkfjsdlfjsldksj</p>
-        </StDetailComment>
-      </StDetailCommentsWrapper>
-
-      <StCommentForm>
-        <StCommentInput type="text" placeholder="댓글을 작성해주세요" />
-        <Button type="submit">SUBMIT</Button>
-      </StCommentForm>
+      <Comments feedId={feedId} />
     </StDetailBox>
   );
 };
@@ -135,65 +110,4 @@ const StDetailUserWrapper = styled.div`
     font-size: 17px;
   }
 `;
-
-//댓글 영역
-const StDetailCommentsWrapper = styled.ul`
-  width: 100%;
-  margin-top: 20px;
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-  border-top: 1px solid #504ba1;
-
-  h1 {
-    font-size: 20px;
-    padding: 0 5px;
-    margin: 20px 0;
-  }
-`;
-
-const StDetailComment = styled.li`
-  width: 100%;
-  display: flex;
-  align-items: center;
-
-  img {
-    width: 50px;
-    height: 50px;
-    border-radius: 50%;
-    background: #ffa600;
-    margin-right: 10px;
-  }
-
-  h3 {
-    width: auto;
-    font-size: 17px;
-    margin-right: 20px;
-  }
-
-  p {
-    width: 100%;
-    font-size: 12px;
-  }
-`;
-
-//댓글 입력 영역
-const StCommentForm = styled.form`
-  width: 100%;
-  margin-top: 50px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 20px;
-`;
-
-const StCommentInput = styled.input`
-  width: 500px;
-  height: 30px;
-  border-radius: 30px;
-  border: 1px solid #504ba1;
-  font-size: 12px;
-  padding: 0 20px;
-`;
-
 export default Detail;

--- a/src/pages/Detail.jsx
+++ b/src/pages/Detail.jsx
@@ -36,6 +36,10 @@ const Detail = () => {
   //CloseButton 클릭시 Feed로 이동 로직
   const navigate = useNavigate();
 
+  const handleNavigateToEdit = () => {
+    navigate(`/edit?id=${feedId}`);
+  };
+
   return (
     <StDetailBox>
       <CloseButton onClick={() => navigate("/feed")} />
@@ -47,7 +51,9 @@ const Detail = () => {
 
         <h1>{selectedFeedData?.title}</h1>
         <p>{selectedFeedData?.contents}</p>
-        <Button type="type">EDIT</Button>
+        <Button type="type" onClick={() => handleNavigateToEdit()}>
+          EDIT
+        </Button>
       </StDetailUserContentsWrapper>
 
       <Comments feedId={feedId} />

--- a/src/pages/Detail.jsx
+++ b/src/pages/Detail.jsx
@@ -93,22 +93,6 @@ const StDetailBox = styled.div`
   justify-content: center;
   align-items: center;
   position: relative;
-
-  .close_btn {
-    position: absolute;
-    top: 30px;
-    right: 30px;
-    background: none;
-    border: none;
-    font-size: 25px;
-    color: #4f4ba1a6;
-    cursor: pointer;
-    transition: all 0.3s;
-
-    &:hover {
-      color: #504ba1;
-    }
-  }
 `;
 
 //user + 본문 영역

--- a/src/pages/Detail.jsx
+++ b/src/pages/Detail.jsx
@@ -1,29 +1,40 @@
 import styled from "styled-components";
 import Button from "../common/Button";
 import CloseButton from "../components/feed/CloseButton";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { useEffect } from "react";
 import { fetchData } from "../api/fetchData";
 import { useState } from "react";
 
 const Detail = () => {
-  //context로 데이터 가져오기
-  //CloseButton 클릭시 Feed로 이동 로직
-  const navigate = useNavigate();
+  //-----url에서 게시글 id 추출-----
+  //query param으로 feed_id 값 가져오기
+  const [searchParams] = useSearchParams();
+  const feedId = searchParams.get("id");
 
-  //feeds 테이블 Data 가져오기
+  //-----data fetch-----
+  //feeds, comments 테이블 Data 가져오기
   const [feedsData, setFeedsData] = useState([]);
+  const [commentsData, setCommentsData] = useState([]);
 
   useEffect(() => {
     async function fetchFeeds() {
-      const newFeedsData = await fetchData("feeds");
+      const newFeedsData = await fetchData("feeds", "users");
+
       setFeedsData(newFeedsData);
     }
 
     fetchFeeds();
   }, []);
 
-  console.log("feedsData", feedsData);
+  //-----해당 게시글 데이터 가져오기-----
+  //게시글 정보
+  const selectedFeedData = feedsData.find((feed) => feed.feed_id === feedId);
+  //작성자 정보
+  const writerData = selectedFeedData?.users;
+
+  //CloseButton 클릭시 Feed로 이동 로직
+  const navigate = useNavigate();
 
   return (
     <StDetailBox>
@@ -31,23 +42,11 @@ const Detail = () => {
       <StDetailUserContentsWrapper>
         <StDetailUserWrapper>
           <img src="/" alt="user_profile_img" />
-          <h3>user</h3>
+          <h3>{writerData?.nickname}</h3>
         </StDetailUserWrapper>
 
-        <h1>title</h1>
-        <p>
-          Lorem ipsum dolor sit amet consectetur adipisicing elit. Molestias
-          totam unde itaque voluptates reiciendis iste vero in exercitationem,
-          quam iusto possimus corporis consectetur suscipit minima. Deserunt
-          quia quidem velit suscipit. Lorem ipsum dolor sit amet consectetur
-          adipisicing elit. Molestias totam unde itaque voluptates reiciendis
-          iste vero in exercitationem, quam iusto possimus corporis consectetur
-          suscipit minima. Deserunt quia quidem velit suscipit. Lorem ipsum
-          dolor sit amet consectetur adipisicing elit. Molestias totam unde
-          itaque voluptates reiciendis iste vero in exercitationem, quam iusto
-          possimus corporis consectetur suscipit minima. Deserunt quia quidem
-          velit suscipit.
-        </p>
+        <h1>{selectedFeedData?.title}</h1>
+        <p>{selectedFeedData?.contents}</p>
         <Button type="type">EDIT</Button>
       </StDetailUserContentsWrapper>
 

--- a/src/pages/Feed.jsx
+++ b/src/pages/Feed.jsx
@@ -20,7 +20,7 @@ const Feed = () => {
 
   return (
     <>
-      feedsData.length && <FeedList posts={feedsData} />
+      <FeedList posts={feedsData} />
       {/* <button onClick={toggleModal}>모달창 열기</button> */}
       {isModalOpen && (
         <Modal onShowModal={toggleModal}>

--- a/src/pages/Feed.jsx
+++ b/src/pages/Feed.jsx
@@ -1,13 +1,11 @@
-import { useState } from "react";
 import FeedList from "../components/feed/FeedList";
-import MOCK_DATA from "../constants/MOCK_DATA";
 
 const Feed = () => {
 
-  const [posts, setPosts] = useState(MOCK_DATA);
+
   return (
     <>
-      <FeedList posts={posts} />
+      <FeedList />
     </>
 
   );

--- a/src/pages/Feed.jsx
+++ b/src/pages/Feed.jsx
@@ -3,12 +3,11 @@ import FeedList from "../components/feed/FeedList";
 import { fetchData } from "../api/fetchData";
 
 const Feed = () => {
-
   const [feedsData, setFeedsData] = useState([]);
 
   useEffect(() => {
     async function fetchFeeds() {
-      const newFeedsData = await fetchData("feeds");
+      const newFeedsData = await fetchData("feeds", "users");
       setFeedsData(newFeedsData);
     }
 
@@ -17,15 +16,7 @@ const Feed = () => {
 
   console.log("feedsData", feedsData);
 
-  return (
-    <>
-      {
-        feedsData.length && <FeedList posts={feedsData} />
-      }
-
-    </>
-
-  );
+  return <>{feedsData.length && <FeedList posts={feedsData} />}</>;
 };
 
 export default Feed;

--- a/src/pages/Feed.jsx
+++ b/src/pages/Feed.jsx
@@ -1,11 +1,28 @@
+import { useEffect, useState } from "react";
 import FeedList from "../components/feed/FeedList";
+import { fetchData } from "../api/fetchData";
 
 const Feed = () => {
 
+  const [feedsData, setFeedsData] = useState([]);
+
+  useEffect(() => {
+    async function fetchFeeds() {
+      const newFeedsData = await fetchData("feeds");
+      setFeedsData(newFeedsData);
+    }
+
+    fetchFeeds();
+  }, []);
+
+  console.log("feedsData", feedsData);
 
   return (
     <>
-      <FeedList />
+      {
+        feedsData.length && <FeedList posts={feedsData} />
+      }
+
     </>
 
   );

--- a/src/pages/FeedEdit.jsx
+++ b/src/pages/FeedEdit.jsx
@@ -1,5 +1,28 @@
+import styled from "styled-components";
+import FeedForm from "../components/feed/FeedForm";
+import CloseButton from "../components/feed/CloseButton";
+
 const FeedEdit = () => {
-  return <div>FeedEdit</div>;
+  return (
+    <StEditBox>
+      <CloseButton></CloseButton>
+      <FeedForm />
+    </StEditBox>
+  );
 };
+
+//-----styled-components-----
+//전체 레이아웃
+const StEditBox = styled.div`
+  width: 80%;
+  border-radius: 30px;
+  background-color: #f7f6ff;
+  padding: 30px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+`;
 
 export default FeedEdit;

--- a/src/pages/FeedEdit.jsx
+++ b/src/pages/FeedEdit.jsx
@@ -1,0 +1,5 @@
+const FeedEdit = () => {
+  return <div>FeedEdit</div>;
+};
+
+export default FeedEdit;

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { Link } from "react-router-dom";
 
 const Login = () => {
   const handleLogin = () => {};
@@ -43,11 +43,11 @@ const Login = () => {
         {/* 소셜 로그인 버튼 */}
         <div>
           <button>
-            <FaGithub />
+            {/* <FaGithub /> */}
             Sign up with Github
           </button>
           <button>
-            <FaGoogle />
+            {/* <FaGoogle /> */}
             Sign up with Google
           </button>
         </div>

--- a/src/shared/Router.jsx
+++ b/src/shared/Router.jsx
@@ -7,6 +7,7 @@ import Mypage from "../pages/Mypage";
 import FindIdPw from "../pages/FindIdPw";
 import Detail from "../pages/Detail";
 import Layout from "../layout/Layout";
+import FeedEdit from "../pages/FeedEdit";
 
 const Router = () => {
   return (
@@ -20,6 +21,7 @@ const Router = () => {
           <Route path="/mypage" element={<Mypage />} />
           <Route path="/findidpw" element={<FindIdPw />} />
           <Route path="/detail" element={<Detail />} />
+          <Route path="/edit" element={<FeedEdit />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/styles/globalStyle.css
+++ b/src/styles/globalStyle.css
@@ -89,3 +89,13 @@ video {
   vertical-align: baseline;
   /* box-sizing: border-box; */
 }
+
+a {
+  text-decoration: none;
+  color: inherit;
+}
+
+ul,
+li {
+  list-style: none;
+}

--- a/src/styles/styledComponents.js
+++ b/src/styles/styledComponents.js
@@ -11,8 +11,4 @@ export const GlobalWrapper = createGlobalStyle`
     width: 100vw;
     background: #504BA1;
   }
-
-  ul, li{
-    list-style: none;
-  }
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1787,7 +1787,7 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prop-types@^15.5.6, prop-types@^15.8.1:
+prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==


### PR DESCRIPTION
### ISSUE 💡
<hr>

- supabase에서 데이터 패치 및 Detail 페이지 구현 + #16
- FeedEdit 페이지 생성 및 `edit`버튼 클릭시 이동 + #22

### WORK 🧑‍🔧
<hr>

- supabase에서 데이터 패치하는 함수 생성 : :file_folder:api - fetchData.js
- Detail 페이지의 UI에 supabase-feeds에서 가져온 데이터 뿌려주기
- Comments 컴포넌트 UI도 supabase-comments에서 가져온 데이터 뿌려주기
<img width="1440" alt="Screenshot 2025-02-15 at 1 35 00 AM" src="https://github.com/user-attachments/assets/59be25d2-7419-4dcb-aaed-5bfde229f364" />

<img width="1440" alt="Screenshot 2025-02-15 at 1 35 05 AM" src="https://github.com/user-attachments/assets/6218561d-4fb8-44b4-baa1-14144f4b5659" />

- `edit`버튼 클릭시 FeedEdit 페이지 이동
![Screen Recording 2025-02-15 at 1 38 17 AM](https://github.com/user-attachments/assets/86313b21-16f8-413b-a7dd-549ad0185007)

### TODO ✅
<hr>

- FeedEdit 페이지 이동시 Detail의 제목/본문 내용이 input 태그에 미리 들어가는 로직 구현
- 게시물 수정 로직 구현
- 댓글 추가/수정 로직 구현