### PR TITLE
style: 스티키 메뉴 위치 수정 및 패딩 조정

### DIFF
--- a/src/layout/StickyMenu.jsx
+++ b/src/layout/StickyMenu.jsx
@@ -33,7 +33,7 @@ const StStickyMenu = styled.div`
   z-index: 50;
 
   .sticky-menu-wrapper{
-    position: absolute;
+    position: sticky;
     top: 50%;
     transform: translateY(-50%);
     left: 0;
@@ -48,7 +48,7 @@ const StStickyMenuItems = styled.nav`
   background-color: #FFFFFF80;
   border-radius:50px;
   border:none;
-  padding: 2rem 1rem;
+  padding: 2rem .5rem;
   display: flex;
   gap: 1rem;
   flex-direction: column;

--- a/src/layout/StickyMenu.jsx
+++ b/src/layout/StickyMenu.jsx
@@ -26,7 +26,7 @@ export default StickyMenu;
 const StStickyMenu = styled.div`
   position: relative;
   display: flex;
-  width: 82px;
+  width: 66px;
   flex-direction: column;
   gap: 1rem;
   margin: 0 2rem;


### PR DESCRIPTION

## #️⃣ 연관된 이슈

- #41

<br>

## 📝 작업 내용

> 스티키 메뉴 스크롤시에도 고정되도록 조절

> 피그마 width에 맞추어 스티키 메뉴 페딩값 조절

<br>

## 🖼 스크린샷

<br>

![스크린샷 2025-02-17 오전 12 08 30](https://github.com/user-attachments/assets/0df7d180-76e4-4b5a-acd5-6e09d2ba34d0)
