### PR TITLE
feat: Detail / Comments 컴포넌트에서 로그인 여부 로직 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "react-router-dom": "6.4.0",
     "redux": "^5.0.1",
     "styled-components": "^6.1.15",
-    "sweetalert2": "^11.17.0"
+    "sweetalert2": "^11.16.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.19.0",

--- a/src/components/feed/Comments.jsx
+++ b/src/components/feed/Comments.jsx
@@ -5,6 +5,8 @@ import { useEffect } from "react";
 import { fetchData } from "../../api/fetchData.js";
 import { insertOrUpdateData } from "../../api/insertOrUpdateData.js";
 import { deleteData } from "../../api/deleteData.js";
+import { useContext } from "react";
+import { AuthContext } from "../../contexts/AuthContext.jsx";
 
 const Comments = ({ feedId }) => {
   //-----data fetch-----
@@ -29,6 +31,9 @@ const Comments = ({ feedId }) => {
     fetchComments();
   }, []);
 
+  //Context로 로그인한 유저의 user_id 값 가져오기
+  const { userId } = useContext(AuthContext);
+
   //-----댓글 추가 기능-----
   //state
   //input value
@@ -51,8 +56,7 @@ const Comments = ({ feedId }) => {
     const newComment = {
       comment: inputValue,
       feed_id: feedId,
-      //writer_id는 임시 데이터값입니다!!
-      writer_id: "1d4b5722-6a09-4256-9b9d-461903075838",
+      writer_id: userId
     };
 
     try {
@@ -106,8 +110,7 @@ const Comments = ({ feedId }) => {
       comment_id,
       comment: editInputValue,
       feed_id: feedId,
-      //writer_id는 임시 데이터값입니다!!
-      writer_id: "1d4b5722-6a09-4256-9b9d-461903075838",
+      writer_id: userId
     };
 
     try {
@@ -180,24 +183,26 @@ const Comments = ({ feedId }) => {
                   <p>{comment.comment}</p>
                 )}
 
-                <StCommentButtonWrapper>
-                  {editingCommentId === comment.comment_id ? (
+                {comment.writer_id === userId && (
+                  <StCommentButtonWrapper>
+                    {editingCommentId === comment.comment_id ? (
+                      <Button
+                        onClick={() => handleEditComment(comment.comment_id)}
+                      >
+                        SAVE
+                      </Button>
+                    ) : (
+                      <Button onClick={() => handleEditButtonClick(comment)}>
+                        EDIT
+                      </Button>
+                    )}
                     <Button
-                      onClick={() => handleEditComment(comment.comment_id)}
+                      onClick={() => handleDeleteComment(comment.comment_id)}
                     >
-                      SAVE
+                      DELETE
                     </Button>
-                  ) : (
-                    <Button onClick={() => handleEditButtonClick(comment)}>
-                      EDIT
-                    </Button>
-                  )}
-                  <Button
-                    onClick={() => handleDeleteComment(comment.comment_id)}
-                  >
-                    DELETE
-                  </Button>
-                </StCommentButtonWrapper>
+                  </StCommentButtonWrapper>
+                )}
               </StDetailComment>
             );
           })

--- a/src/components/feed/Comments.jsx
+++ b/src/components/feed/Comments.jsx
@@ -266,16 +266,17 @@ const StDetailComment = styled.li`
 
   //유저 닉네임
   h3 {
-    width: 10%;
+    width: 80px;
     font-size: 17px;
     margin-right: 20px;
   }
 
   //댓글 본문
   p {
-    width: 70%;
+    width: 50%;
     font-size: 12px;
     padding: 10px;
+    overflow-wrap: break-word;
   }
 `;
 //댓글 수정 입력창

--- a/src/components/feed/Comments.jsx
+++ b/src/components/feed/Comments.jsx
@@ -138,16 +138,20 @@ const Comments = ({ feedId }) => {
   //삭제 함수
   const handleDeleteComment = async (comment_id) => {
     try {
-      //supabase에 삭제
-      await deleteData("comments", "comment_id", comment_id);
-      alert("댓글이 삭제 되었습니다!");
+      const isConfirm = window.confirm("정말로 삭제하시겠습니까?");
 
-      //댓글 목록을 새롭게 fetch해서 즉시 반영하기
-      const comments = await fetchData("comments", "users");
-      const newComments = comments.filter(
-        (comment) => comment.feed_id === feedId
-      );
-      setCommentsData(newComments);
+      if (isConfirm) {
+        //supabase에 삭제
+        await deleteData("comments", "comment_id", comment_id);
+        alert("댓글이 삭제 되었습니다!");
+
+        //댓글 목록을 새롭게 fetch해서 즉시 반영하기
+        const comments = await fetchData("comments", "users");
+        const newComments = comments.filter(
+          (comment) => comment.feed_id === feedId
+        );
+        setCommentsData(newComments);
+      }
     } catch (error) {
       console.log("delete comment error => ", error);
       //사용자 알림

--- a/src/components/feed/FeedCard.jsx
+++ b/src/components/feed/FeedCard.jsx
@@ -3,7 +3,7 @@ import Like from "./Like";
 import { deleteData } from "../../api/deleteData";
 import { FaRegTrashAlt } from "react-icons/fa";
 import { useContext } from "react";
-import { AuthContext } from "../../contexts/TestAuthContext";
+import { AuthContext } from "../../contexts/AuthContext";
 
 const FeedCard = ({ post, setPosts }) => {
   const { userId } = useContext(AuthContext);

--- a/src/components/feed/FeedCard.jsx
+++ b/src/components/feed/FeedCard.jsx
@@ -2,8 +2,12 @@ import styled from "styled-components";
 import Like from "./Like";
 import { deleteData } from "../../api/deleteData";
 import { FaRegTrashAlt } from "react-icons/fa";
+import { useContext } from "react";
+import { AuthContext } from "../../contexts/TestAuthContext";
 
 const FeedCard = ({ post, setPosts }) => {
+  const { userId } = useContext(AuthContext);
+
   // 게시글 삭제 함수
   const handleDeletePost = async (e, id) => {
     e.preventDefault();
@@ -29,7 +33,7 @@ const FeedCard = ({ post, setPosts }) => {
         <StContents>{post.contents}</StContents>
       </StFeedCardContent>
 
-      {post.writer_id === post.users.user_id && (
+      {post.writer_id === userId && (
         <StDeleteButton onClick={(e) => handleDeletePost(e, post.feed_id)}>
           <StTrashIcon />
         </StDeleteButton>

--- a/src/components/feed/FeedForm.jsx
+++ b/src/components/feed/FeedForm.jsx
@@ -9,18 +9,17 @@ import { useForm } from "react-hook-form";
 import { AuthContext } from "../../contexts/AuthContext";
 import { useEffect } from "react";
 
-
 // 초기 피드 데이터를 정의 (title과 contents는 빈 문자열로 설정)
 const INITIAL_ADD_FEED_DATA = {
   title: "",
-  contents: "",
+  contents: ""
 };
 
 // 금칙어 목록을 정의. 추후 슈파베이스 테이블로 관리해도 좋을듯
 const BANNED_WORDS = ["나쁜말1", "나쁜말2", "나쁜말3"];
 
 // Feed 추가 Form 별도 분리
-const AddFeedForm = ({userId}) => {
+const AddFeedForm = ({ userId }) => {
   // FeedContext에서 toggleModal 함수를 가져옴 (모달을 열거나 닫을 때 사용)
   const { toggleModal } = useContext(FeedContext);
 
@@ -28,9 +27,9 @@ const AddFeedForm = ({userId}) => {
   const {
     handleSubmit,
     register,
-    formState: { errors },
+    formState: { errors }
   } = useForm({
-    defaultValues: INITIAL_ADD_FEED_DATA,
+    defaultValues: INITIAL_ADD_FEED_DATA
   });
 
   // 금칙어 필터링
@@ -42,15 +41,6 @@ const AddFeedForm = ({userId}) => {
       return true;
     }
   };
-
-  // // onChange시에 event와 field 객체를 받아, input value 추가
-  // const handleInputChange = (e, field) => {
-  //   const { value } = e.target;
-  //   setAddFeedData((state) => ({
-  //     ...state,
-  //     [field]: value,
-  //   }));
-  // };
 
   // 실제 테이블에 feed 데이터 추가하는 함수
   const handleAddFeed = (data) => {
@@ -64,8 +54,8 @@ const AddFeedForm = ({userId}) => {
     // feed 데이터를 확장 (writer_id 추가)
     const feedData = {
       ...data,
-      writer_id: userId,
-    }
+      writer_id: userId
+    };
 
     // 데이터 삽입 또는 업데이트 함수 호출
     insertOrUpdateData(feedData, "feeds");
@@ -89,13 +79,13 @@ const AddFeedForm = ({userId}) => {
             required: true,
             minLength: {
               value: 6,
-              message: "※ 제목은 최소 6자 이상이어야 합니다",
+              message: "※ 제목은 최소 6자 이상이어야 합니다"
             },
             maxLength: {
               value: 50,
-              message: "※ 제목은 최대 50자를 초과할 수 없습니다",
+              message: "※ 제목은 최대 50자를 초과할 수 없습니다"
             },
-            setValueAs: (value) => value.trim(), // 입력값 양옆 공백 제거
+            setValueAs: (value) => value.trim() // 입력값 양옆 공백 제거
           })}
         />
         {/* 제목 입력시 발생할 수 있는 에러 메시지 */}
@@ -121,13 +111,13 @@ const AddFeedForm = ({userId}) => {
             required: true,
             minLength: {
               value: 6,
-              message: "※ 내용은 최소 6자 이상이어야 합니다",
+              message: "※ 내용은 최소 6자 이상이어야 합니다"
             },
             maxLength: {
               value: 500,
-              message: "※ 내용은 500자를 초과할 수 없습니다",
+              message: "※ 내용은 500자를 초과할 수 없습니다"
             },
-            setValueAs: (value) => value.trim(), // 입력값 양옆 공백 제거
+            setValueAs: (value) => value.trim() // 입력값 양옆 공백 제거
           })}
         />
         {/* 내용 입력시 발생할 수 있는 에러 메시지 */}
@@ -148,25 +138,21 @@ const AddFeedForm = ({userId}) => {
 };
 
 //-----editFeedMode 게시글 수정 컴포넌트-----
-const EditFeedForm = ({ feedId }) => {
+const EditFeedForm = ({ feedId, userId }) => {
   //react-hook-form을 사용하여 폼 데이터 관리
   const INITIAL_EDIT_FEED_DATA = {
     title: "",
-    contents: "",
+    contents: ""
   };
 
   const {
     handleSubmit,
     register,
     setValue,
-    formState: { errors },
+    formState: { errors }
   } = useForm({
-    defaultValues: INITIAL_EDIT_FEED_DATA,
+    defaultValues: INITIAL_EDIT_FEED_DATA
   });
-
-  // //state
-  // const [editTitle, setEditTitle] = useState("");
-  // const [editContents, setEditContents] = useState("");
 
   //-----data fetch-----
   useEffect(() => {
@@ -201,15 +187,6 @@ const EditFeedForm = ({ feedId }) => {
     }
   };
 
-  //Edit input 체인지 이벤트 핸들러
-  // const handleEditTitleChange = (e) => {
-  //   setEditTitle(e.target.value);
-  // };
-
-  // const handleEditContentChange = (e) => {
-  //   setEditContents(e.target.value);
-  // };
-
   //게시글 수정 함수
   const handleEditFeedSubmit = async (data) => {
     //예외처리: 금칙어
@@ -226,8 +203,7 @@ const EditFeedForm = ({ feedId }) => {
       feed_id: feedId,
       title: data.title,
       contents: data.contents,
-      //writer_id는 임시 데이터값입니다!!!
-      writer_id: "44319787-433a-4f21-b2dc-309ddfc7e21c",
+      writer_id: userId
     };
 
     try {
@@ -261,13 +237,13 @@ const EditFeedForm = ({ feedId }) => {
             required: true,
             minLength: {
               value: 6,
-              message: "※ 제목은 최소 6자 이상이어야 합니다",
+              message: "※ 제목은 최소 6자 이상이어야 합니다"
             },
             maxLength: {
               value: 50,
-              message: "※ 제목은 최대 50자를 초과할 수 없습니다",
+              message: "※ 제목은 최대 50자를 초과할 수 없습니다"
             },
-            setValueAs: (value) => value.trim(),
+            setValueAs: (value) => value.trim()
           })}
         />
         {errors.title && (
@@ -291,13 +267,13 @@ const EditFeedForm = ({ feedId }) => {
             required: true,
             minLength: {
               value: 6,
-              message: "※ 본문은 최소 6자 이상이어야 합니다",
+              message: "※ 본문은 최소 6자 이상이어야 합니다"
             },
             maxLength: {
               value: 500,
-              message: "※ 내용은 500자를 초과할 수 없습니다",
+              message: "※ 내용은 500자를 초과할 수 없습니다"
             },
-            setValueAs: (value) => value.trim(),
+            setValueAs: (value) => value.trim()
           })}
         />
         {errors.contents && (
@@ -317,12 +293,14 @@ const EditFeedForm = ({ feedId }) => {
 };
 
 const FeedForm = ({ isMode, feedId }) => {
+  const { userId } = useContext(AuthContext);
+
   return (
     <>
       {isMode === "addFeedMode" ? (
-        <AddFeedForm />
+        <AddFeedForm userId={userId} />
       ) : (
-        <EditFeedForm feedId={feedId} />
+        <EditFeedForm feedId={feedId} userId={userId} />
       )}
     </>
   );

--- a/src/pages/Detail.jsx
+++ b/src/pages/Detail.jsx
@@ -6,12 +6,18 @@ import { useEffect } from "react";
 import { fetchData } from "../api/fetchData";
 import { useState } from "react";
 import Comments from "../components/feed/Comments";
+import { useContext } from "react";
+import { AuthContext } from "../contexts/AuthContext";
+import { deleteData } from "../api/deleteData";
 
 const Detail = () => {
-  //-----url에서 게시글 id 추출-----
-  //query param으로 feed_id 값 가져오기
+  //-----feed_id / user_id-----
+  //url에서 게시글 id 추출 : query param으로 feed_id 값 가져오기
   const [searchParams] = useSearchParams();
   const feedId = searchParams.get("feed_id");
+
+  //Context로 로그인한 유저의 user_id 값 가져오기
+  const { userId } = useContext(AuthContext);
 
   //-----data fetch-----
   //feeds, comments 테이블 Data 가져오기
@@ -40,6 +46,18 @@ const Detail = () => {
     navigate(`/edit?feed_id=${feedId}`);
   };
 
+  //-----해당 게시글 삭제 로직-----
+  const handleDeletePost = async (feed_id) => {
+    //사용자 확인 여부
+    const isConfirm = window.confirm("정말 삭제하시겠습니까?");
+    if (isConfirm) {
+      //supabase 데이터 삭제
+      await deleteData("feeds", "feed_id", feed_id);
+      //feed로 이동
+      navigate("/feed");
+    }
+  };
+
   return (
     <StDetailBox>
       <CloseButton onClick={() => navigate("/feed")} />
@@ -51,9 +69,12 @@ const Detail = () => {
 
         <h1>{selectedFeedData?.title}</h1>
         <p>{selectedFeedData?.contents}</p>
-        <Button type="type" onClick={() => handleNavigateToEdit()}>
-          EDIT
-        </Button>
+        {selectedFeedData?.writer_id === userId && (
+          <StDetailButtonWrapper>
+            <Button onClick={handleNavigateToEdit}>EDIT</Button>
+            <Button onClick={() => handleDeletePost(feedId)}>DELETE</Button>
+          </StDetailButtonWrapper>
+        )}
       </StDetailUserContentsWrapper>
 
       <Comments feedId={feedId} />
@@ -116,4 +137,12 @@ const StDetailUserWrapper = styled.div`
     font-size: 17px;
   }
 `;
+
+//EDIT/DELETE 버튼 wrapper
+const StDetailButtonWrapper = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+`;
+
 export default Detail;

--- a/src/pages/FeedEdit.jsx
+++ b/src/pages/FeedEdit.jsx
@@ -2,6 +2,7 @@ import styled from "styled-components";
 import FeedForm from "../components/feed/FeedForm";
 import CloseButton from "../components/feed/CloseButton";
 import { useSearchParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 const FeedEdit = () => {
   //-----url에서 게시글 id 추출-----
@@ -9,9 +10,21 @@ const FeedEdit = () => {
   const [searchParams] = useSearchParams();
   const feedId = searchParams.get("feed_id");
 
+  //CloseButton 클릭시 Detail 페이지로 이동
+  const navigate = useNavigate();
+
+  const handleNavigateToDetail = () => {
+    //사용자 확인 여부
+    const isConfirm = window.confirm("수정을 그만두시겠습니까?");
+
+    if (isConfirm) {
+      navigate(`/detail?feed_id=${feedId}`);
+    }
+  };
+
   return (
     <StEditBox>
-      <CloseButton></CloseButton>
+      <CloseButton onClick={handleNavigateToDetail}></CloseButton>
       <FeedForm feedId={feedId} />
     </StEditBox>
   );

--- a/src/pages/Mypage.jsx
+++ b/src/pages/Mypage.jsx
@@ -10,7 +10,7 @@ const MyPage = () => {
     name: "",
     email: "",
     nickname: "",
-    image: "",
+    image: ""
   });
 
   return (
@@ -51,7 +51,8 @@ const MyPage = () => {
         <div></div>
       </StContentsHeader>
       <StContentBoxWrapper>
-        //지금은 기본 UI 이기때문에 예시 데이터로 여러개 만들어둠. 추후 supabase로 데이터 가져와서 map사용할예정정
+        {/* 지금은 기본 UI 이기때문에 예시 데이터로 여러개 만들어둠. 추후
+supabase로 데이터 가져와서 map사용할예정정 */}
         <StContentBox>
           <h2>팀 프로젝트 발제</h2>
           <p>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Detail / FeedEdit 페이지에서 로그인 여부 확인 후 writer_id와 로그인한 user_id 같은 경우 수정버튼, 삭제버튼 보여지도록 로직 구현 #50

<br>

## 📝 작업 내용

> Detail 페이지에서 작성자인 경우에만 수정버튼, 삭제버튼 보여지도록 로직 구현
> Comments 컴포넌트에서 작성자인 경우에만 수정버튼, 삭제버튼 보여지도록 로직 구현

<br>

## 🖼 스크린샷

<img width="1440" alt="Screenshot 2025-02-17 at 2 23 38 AM" src="https://github.com/user-attachments/assets/61758607-9f40-4085-8998-e3faaca15bab" />

<br>

## 💬리뷰 요구사항

> 혹여나 제가 로그인 로직 관련해서 놓친 부분이 있다면 꼭 알려주세요! 빠르게 수정 후 다시 푸시하겠습니다!