### PR TITLE
[FEAT] 디테일 페이지 업로드 된 프로필 이미지 보여주는 기능 추가 #92

### DIFF
--- a/src/pages/Detail.jsx
+++ b/src/pages/Detail.jsx
@@ -64,7 +64,11 @@ const Detail = () => {
       <CloseButton onClick={() => navigate("/feed")} />
       <StDetailUserContentsWrapper>
         <StDetailUserWrapper>
-          <StUserProfileImage src={writerData?.profile_img} />
+          {console.log(writerData)}
+          <StUserProfileImage src={writerData?.profile_img
+            ? `${import.meta.env.VITE_APP_SUPABASE_STORAGE_URL}${writerData?.profile_img}`
+            : DEFAULT_PROFILE_IMG
+          } />
           <h3>{writerData?.nickname}</h3>
         </StDetailUserWrapper>
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- 디테일 페이지 프로필 이미지 기능 #92 

<br>

## 📝 작업 내용

> Detail 페이지에서 등록한 프로필 이미지를 보여주고 등록되지 않으면 기본 이미지 보여주기

<br>

## 
![456](https://github.com/user-attachments/assets/90f71196-8c54-450b-a891-f0cf897e36e3)


<br>
