### PR TITLE
[FEAT]  detail 페이지 comments에 프로필 이미지 출력

### DIFF
--- a/src/components/feed/Comments.jsx
+++ b/src/components/feed/Comments.jsx
@@ -199,7 +199,10 @@ const Comments = ({ feedId }) => {
           commentsData.map((comment) => {
             return (
               <StDetailComment key={comment.comment_id}>
-                <StUserProfileImage src={comment.users.profile_img} />
+                <StUserProfileImage src={comment.users.profile_img
+                  ? `${import.meta.env.VITE_APP_SUPABASE_STORAGE_URL}${comment.users.profile_img}`
+                  : DEFAULT_PROFILE_IMG
+                } />
                 <h3>{comment.users.nickname}</h3>
                 {editingCommentId === comment.comment_id ? (
                   <StCommentEditInput


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- detail 페이지 comments에 프로필 이미지 보여주는 기능 추가 #94 
<br>

## 📝 작업 내용

> 업로드 된 프로필 이미지 comments에도 보여주기
업로드된 이미지가 없으면 지정된 기본 이미지가 보여짐

<br>

## 
![789](https://github.com/user-attachments/assets/75ac6616-3b2c-4422-a4c9-929f798e6882)