### PR TITLE
feat: 사용자 닉네임을 헤더에 표시하도록 수정

### DIFF
--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -8,6 +8,7 @@ import { AlertSuccess } from "../components/common/Alert";
 
 const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false); // 메뉴 열고 닫는 상태
+  const [userNickname, setUserNickName] = useState('');
   const { isLogin, setIsLogin, setUser, setUserId } = useContext(AuthContext);
   const navigate = useNavigate();
 
@@ -22,6 +23,7 @@ const Header = () => {
 
       setIsLogin(session?.user ?? null);
       setUser(session?.user || null);
+      setUserNickName(session?.user.user_metadata.nickname || '게스트')
     };
 
     getSession();
@@ -63,15 +65,20 @@ const Header = () => {
         </StMenuToggle>
         <StNavLink $isOpen={isMenuOpen}>
           {isLogin ? (
-            <StSubLink
-              to="/"
-              onClick={(e) => {
-                e.preventDefault(); // 기본 이동 막기
-                handleLogout(); // 로그아웃 실행
-              }}
-            >
-              Logout
-            </StSubLink>
+            <>
+              <div className="home-user-nickname">
+                <span className="nickname-highlight">{userNickname}</span> 의 티타임
+              </div>
+              <StSubLink
+                to="/"
+                onClick={(e) => {
+                  e.preventDefault(); // 기본 이동 막기
+                  handleLogout(); // 로그아웃 실행
+                }}
+              >
+                Logout
+              </StSubLink>
+            </>
           ) : (
             <>
               <StSubLink to="/signup" $isJoin>
@@ -158,6 +165,14 @@ const StNavLink = styled.div`
   flex-direction: row;
   align-items: center;
   gap: 1rem;
+
+  .home-user-nickname {
+    color: #2c3e50;
+    font-weight: 500;
+    .nickname-highlight{
+      color: #7738c8;
+    }
+  }
 
   @media (max-width: 768px) {
     display: ${({ $isOpen }) => ($isOpen ? "flex" : "none")};


### PR DESCRIPTION
## 📝 작업 내용

> 로그인 시 사용자 닉네임을 헤더에 표시

<br>

## 🖼 스크린샷

<br>
<img width="1027" alt="스크린샷 2025-02-18 오전 10 42 01" src="https://github.com/user-attachments/assets/cc4c9aa1-6c0c-4059-a6b7-0acab1d1c011" />
